### PR TITLE
Fix Lag EngineMassiveCoreCollTick.java

### DIFF
--- a/src/com/massivecraft/massivecore/engine/EngineMassiveCoreCollTick.java
+++ b/src/com/massivecraft/massivecore/engine/EngineMassiveCoreCollTick.java
@@ -28,7 +28,7 @@ public class EngineMassiveCoreCollTick extends EngineAbstract
 	@Override
 	public Long getPeriod()
 	{
-		return 1L;
+		return 500L;
 	}
 	
 	// -------------------------------------------- //


### PR DESCRIPTION
Fixes persistent lag issue that'll cause up to 80% TPS loss.
Save interval is now every 500 ticks instead of every 1 tick. This'll save server performance in the long run and prevent lag issues with larger Factions servers.

https://gyazo.com/de62ac3758bd3e4409695e2b162f620f Timings report with interval set to 1
https://gyazo.com/5e4cc3128c20fa350a09eec0bf953d6a Timings report with new interval

Huge performance increase.